### PR TITLE
Add support for Continuous Delivery

### DIFF
--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -1,0 +1,18 @@
+on:
+  pull_request:
+    types: [ opened, synchronize, closed ]
+    branches:
+      - main
+
+jobs:
+  balena_cloud_build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: balena-io/deploy-to-balena-action@master
+        id: build
+        with:
+          balena_token: ${{ secrets.BALENA_TOKEN }}
+          fleet: gh_kappsegla/demo
+      - name: Log release ID built
+        run: echo "Built release ID ${{ steps.build.outputs.release_id }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM maven:3-eclipse-temurin-21-alpine AS builder
+WORKDIR build
+COPY . .
+RUN mvn clean package -DskipTests
+
+FROM eclipse-temurin:21-jre-alpine AS layers
+WORKDIR layer
+COPY --from=builder /build/target/*.jar app.jar
+RUN java -Djarmode=layertools -jar app.jar extract
+
+FROM eclipse-temurin:21-jre-alpine
+WORKDIR /opt/app
+RUN addgroup --system appuser && adduser -S -s /usr/sbin/nologin -G appuser appuser
+COPY --from=layers /layer/dependencies/ ./
+COPY --from=layers /layer/spring-boot-loader/ ./
+COPY --from=layers /layer/snapshot-dependencies/ ./
+COPY --from=layers /layer/application/ ./
+RUN chown -R appuser:appuser /opt/app
+USER appuser
+HEALTHCHECK --start-period=60s --interval=180s --timeout=3s --retries=3 CMD wget -qO- http://localhost:8080/actuator/health/ | grep UP || exit 1
+ENTRYPOINT ["java", "org.springframework.boot.loader.launch.JarLauncher"]

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,15 @@
             <artifactId>flyway-core</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-mysql</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
@@ -49,6 +58,10 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
     </dependencies>
 
     <build>
@@ -72,5 +85,4 @@
             </plugin>
         </plugins>
     </build>
-
 </project>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,6 @@
-
+spring.datasource.url=${DATASOURCE_URL:jdbc:mysql://localhost:3306/mmotodo}
+spring.datasource.username=${DATASOURCE_USERNAME:root}
+spring.datasource.password=${DATASOURCE_PASSWORD:root}
+spring.jpa.open-in-view=false
+spring.threads.virtual.enabled=true
+server.forward-headers-strategy=framework


### PR DESCRIPTION
Adds multistage Dockerfile for building dockerimage. Adds spring-boot-starter-actuator to pom.xml to enable health checks. delivery.yml github action for automatic deployments.

Changes to application.properties
Enable virtual threads
Set forward-headers-strategy=framework to enable X- headers behind gateway. Add environment variables with default values for. DATASOURCE_URL, DATASOURCE_USERNAME and DATASOURCE_PASSWORD

Closes #3 