### PR TITLE
40 task optimize db queries

### DIFF
--- a/src/main/java/org/fungover/mmotodo/category/CategoryRepository.java
+++ b/src/main/java/org/fungover/mmotodo/category/CategoryRepository.java
@@ -2,5 +2,8 @@ package org.fungover.mmotodo.category;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface CategoryRepository extends JpaRepository<Category, Integer> {
+    List<Category> findByIdIn(List<Integer> categoryIdList);
 }

--- a/src/main/java/org/fungover/mmotodo/category/CategoryService.java
+++ b/src/main/java/org/fungover/mmotodo/category/CategoryService.java
@@ -3,10 +3,8 @@ package org.fungover.mmotodo.category;
 import org.fungover.mmotodo.task.Task;
 import org.springframework.stereotype.Service;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 @Service
@@ -31,7 +29,7 @@ public class CategoryService {
                                         categories.stream()
                                                 .filter(c -> c.getId().equals(task.getCategory().getId()))
                                                 .findFirst()
-                                                .orElse(null)));
+                                                .orElse(new Category())));
     }
 }
 

--- a/src/main/java/org/fungover/mmotodo/category/CategoryService.java
+++ b/src/main/java/org/fungover/mmotodo/category/CategoryService.java
@@ -1,0 +1,38 @@
+package org.fungover.mmotodo.category;
+
+import org.fungover.mmotodo.task.Task;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Service
+public class CategoryService {
+    private final CategoryRepository categoryRepository;
+
+    public CategoryService(CategoryRepository categoryRepository) {
+        this.categoryRepository = categoryRepository;
+    }
+
+    public List<Category> category(List<Integer> taskIds) {
+        return categoryRepository.findAllById(taskIds);
+    }
+
+    public Map<Task, Category> categoriesForTasks(List<Task> tasks) {
+        var categories =categoryRepository.findAll();
+        return tasks.stream()
+                .collect(
+                        Collectors.toMap(
+                                task -> task    ,
+                                task ->
+                                        categories.stream()
+                                                .filter(c -> c.getId().equals(task.getCategory().getId()))
+                                                .findFirst()
+                                                .orElse(null)));
+    }
+}
+
+

--- a/src/main/java/org/fungover/mmotodo/category/CategoryService.java
+++ b/src/main/java/org/fungover/mmotodo/category/CategoryService.java
@@ -15,10 +15,6 @@ public class CategoryService {
         this.categoryRepository = categoryRepository;
     }
 
-    public List<Category> category(List<Integer> taskIds) {
-        return categoryRepository.findAllById(taskIds);
-    }
-
     public Map<Task, Category> categoriesForTasks(List<Task> tasks) {
         var categories =categoryRepository.findAll();
         return tasks.stream()

--- a/src/main/java/org/fungover/mmotodo/category/CategoryService.java
+++ b/src/main/java/org/fungover/mmotodo/category/CategoryService.java
@@ -16,7 +16,10 @@ public class CategoryService {
     }
 
     public Map<Task, Category> categoriesForTasks(List<Task> tasks) {
-        var categories =categoryRepository.findAll();
+
+        var categoryIds = tasks.stream().map(task -> task.getCategory().getId()).collect(Collectors.toList());
+        var categories = categoryRepository.findByIdIn(categoryIds);
+
         return tasks.stream()
                 .collect(
                         Collectors.toMap(
@@ -28,5 +31,3 @@ public class CategoryService {
                                                 .orElse(new Category())));
     }
 }
-
-

--- a/src/main/java/org/fungover/mmotodo/tag/TagRepository.java
+++ b/src/main/java/org/fungover/mmotodo/tag/TagRepository.java
@@ -2,5 +2,8 @@ package org.fungover.mmotodo.tag;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface TagRepository extends JpaRepository<Tag, Integer> {
+    List<Tag> findByIdIn(List<Integer> taskIdList);
 }

--- a/src/main/java/org/fungover/mmotodo/tag/TagService.java
+++ b/src/main/java/org/fungover/mmotodo/tag/TagService.java
@@ -1,0 +1,30 @@
+package org.fungover.mmotodo.tag;
+
+import org.fungover.mmotodo.task.Task;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+public class TagService {
+    private final TagRepository tagRepository;
+
+    public TagService(TagRepository TagRepository) {
+        this.tagRepository = TagRepository;
+    }
+
+    public Map<Task, Tag> tagsForTasks(List<Task> tasks) {
+        var tags = tagRepository.findAll();
+        return tasks.stream()
+                .collect(
+                        Collectors.toMap(
+                                task -> task    ,
+                                task ->
+                                        tags.stream()
+                                                .filter(c -> c.getId().equals(task.getTag().getId()))
+                                                .findFirst()
+                                                .orElse(new Tag())));
+    }
+}

--- a/src/main/java/org/fungover/mmotodo/tag/TagService.java
+++ b/src/main/java/org/fungover/mmotodo/tag/TagService.java
@@ -16,7 +16,10 @@ public class TagService {
     }
 
     public Map<Task, Tag> tagsForTasks(List<Task> tasks) {
-        var tags = tagRepository.findAll();
+
+        var tagIds = tasks.stream().map(task -> task.getTag().getId()).collect(Collectors.toList());
+        var tags = tagRepository.findByIdIn(tagIds);
+
         return tasks.stream()
                 .collect(
                         Collectors.toMap(

--- a/src/main/java/org/fungover/mmotodo/task/Task.java
+++ b/src/main/java/org/fungover/mmotodo/task/Task.java
@@ -58,7 +58,7 @@ public class Task {
     private String status;
 
     @NotNull
-    @ManyToOne(fetch = FetchType.EAGER, optional = false)
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "tag_id", nullable = false)
     private Tag tag;
 

--- a/src/main/java/org/fungover/mmotodo/task/Task.java
+++ b/src/main/java/org/fungover/mmotodo/task/Task.java
@@ -63,7 +63,7 @@ public class Task {
     private Tag tag;
 
     @NotNull
-    @ManyToOne(fetch = FetchType.EAGER, optional = false)
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "category_id", nullable = false)
     private Category category;
 

--- a/src/main/java/org/fungover/mmotodo/task/TaskController.java
+++ b/src/main/java/org/fungover/mmotodo/task/TaskController.java
@@ -1,22 +1,24 @@
 package org.fungover.mmotodo.task;
 
 import jakarta.validation.Valid;
-import org.springframework.graphql.data.method.annotation.Argument;
-import org.springframework.graphql.data.method.annotation.MutationMapping;
-import org.springframework.graphql.data.method.annotation.QueryMapping;
-import org.springframework.graphql.data.method.annotation.SubscriptionMapping;
+import org.fungover.mmotodo.category.Category;
+import org.fungover.mmotodo.category.CategoryService;
+import org.springframework.graphql.data.method.annotation.*;
 import org.springframework.stereotype.Controller;
 import reactor.core.publisher.Flux;
 
 import java.util.List;
+import java.util.Map;
 
 @Controller
 public class TaskController {
     private final TaskService taskService;
+    private final CategoryService categoryService;
     private final Flux<TaskEvent> taskEvent;
 
-    public TaskController(TaskService taskService, Flux<TaskEvent> taskEvent) {
+    public TaskController(TaskService taskService, CategoryService categoryService, Flux<TaskEvent> taskEvent) {
         this.taskService = taskService;
+        this.categoryService = categoryService;
         this.taskEvent = taskEvent;
     }
 
@@ -61,5 +63,10 @@ public class TaskController {
     @SubscriptionMapping
     public Flux<TaskEvent> taskEvent() {
         return taskEvent;
+    }
+
+    @BatchMapping
+    public Map<Task, Category> category(List<Task> tasks) {
+        return categoryService.categoriesForTasks(tasks);
     }
 }

--- a/src/main/java/org/fungover/mmotodo/task/TaskController.java
+++ b/src/main/java/org/fungover/mmotodo/task/TaskController.java
@@ -3,6 +3,8 @@ package org.fungover.mmotodo.task;
 import jakarta.validation.Valid;
 import org.fungover.mmotodo.category.Category;
 import org.fungover.mmotodo.category.CategoryService;
+import org.fungover.mmotodo.tag.Tag;
+import org.fungover.mmotodo.tag.TagService;
 import org.springframework.graphql.data.method.annotation.*;
 import org.springframework.stereotype.Controller;
 import reactor.core.publisher.Flux;
@@ -14,11 +16,13 @@ import java.util.Map;
 public class TaskController {
     private final TaskService taskService;
     private final CategoryService categoryService;
+    private final TagService tagService;
     private final Flux<TaskEvent> taskEvent;
 
-    public TaskController(TaskService taskService, CategoryService categoryService, Flux<TaskEvent> taskEvent) {
+    public TaskController(TaskService taskService, CategoryService categoryService, TagService tagService, Flux<TaskEvent> taskEvent) {
         this.taskService = taskService;
         this.categoryService = categoryService;
+        this.tagService = tagService;
         this.taskEvent = taskEvent;
     }
 
@@ -68,5 +72,10 @@ public class TaskController {
     @BatchMapping
     public Map<Task, Category> category(List<Task> tasks) {
         return categoryService.categoriesForTasks(tasks);
+    }
+
+    @BatchMapping
+    public Map<Task, Tag> tag(List<Task> tasks) {
+        return tagService.tagsForTasks(tasks);
     }
 }


### PR DESCRIPTION
n+1 problem solved with the help of @BatchMapping. 
The BatchMapping shown in this pullrequest helps to relieve the database from unnecessary quering by doing a batchrequest for each nested Tag and Category in all of the requested tasks. 

fetchtype had to be set to LAZY in the Task entity for this to work, otherwise graphql defaulted to using the unnecessary database calls. 

Having the fk-relations (Category and Tag) in Task set to LAZY also removes the unnecessary database fetching for these nested fields when they are not requested by the client. They are only batchrequested when they are asked for.