### PR TITLE
12 rest controller tasks

### DIFF
--- a/src/main/java/org/fungover/mmotodo/task/TaskRestController.java
+++ b/src/main/java/org/fungover/mmotodo/task/TaskRestController.java
@@ -1,7 +1,6 @@
 package org.fungover.mmotodo.task;
 
 import jakarta.validation.Valid;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -14,36 +13,40 @@ public class TaskRestController {
 
     public final TaskService service;
 
-    @Autowired
     public TaskRestController(TaskService service) {
         this.service = service;
     }
 
     @GetMapping
-    public ResponseEntity<List<Task>> getAllTasks(){
+    public ResponseEntity<List<Task>> getAllTasks() {
+
         return ResponseEntity.ok(service.getAllTasks());
     }
+
     @PostMapping
-    public ResponseEntity<Task> createTask(@Valid @RequestBody TaskCreateDto newTask){
+    public ResponseEntity<Task> createTask(@Valid @RequestBody TaskCreateDto newTask) {
         Task task = service.addTask(newTask);
         return ResponseEntity.status(HttpStatus.CREATED).body(task);
     }
+
     @PutMapping("/{id}")
-    public ResponseEntity<?> updateTask(@PathVariable int id, @Valid @RequestBody TaskUpdateDto updatedTask){
-        if(updatedTask.id() != id){
+    public ResponseEntity<?> updateTask(@PathVariable int id, @Valid @RequestBody TaskUpdateDto updatedTask) {
+        if (updatedTask.id() != id) {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Mismatched task ID");
         }
         Task task = service.updateTask(updatedTask);
         return ResponseEntity.ok(task);
     }
+
     @GetMapping("/{id}")
-    public ResponseEntity<Task> getTaskById(@PathVariable int id){
+    public ResponseEntity<Task> getTaskById(@PathVariable int id) {
         Task task = service.getTaskById(id);
         return ResponseEntity.ok(task);
     }
+
     @DeleteMapping("/{id}")
-    public ResponseEntity<String> deleteTask(@PathVariable int id){
-        if(service.deleteTask(id)) {
+    public ResponseEntity<String> deleteTask(@PathVariable int id) {
+        if (service.deleteTask(id)) {
             return ResponseEntity.noContent().build();
         }
         return ResponseEntity.status(HttpStatus.NOT_FOUND).build();

--- a/src/main/java/org/fungover/mmotodo/task/TaskRestController.java
+++ b/src/main/java/org/fungover/mmotodo/task/TaskRestController.java
@@ -1,0 +1,52 @@
+package org.fungover.mmotodo.task;
+
+import jakarta.validation.Valid;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/tasks")
+public class TaskRestController {
+
+    public final TaskService service;
+
+    @Autowired
+    public TaskRestController(TaskService service) {
+        this.service = service;
+    }
+
+    @GetMapping
+    public ResponseEntity<List<Task>> getAllTasks(){
+        return ResponseEntity.ok(service.getAllTasks());
+    }
+    @PostMapping
+    public ResponseEntity<Task> createTask(@Valid @RequestBody TaskCreateDto newTask){
+        Task task = service.addTask(newTask);
+        return ResponseEntity.status(HttpStatus.CREATED).body(task);
+    }
+    @PutMapping("/{id}")
+    public ResponseEntity<?> updateTask(@PathVariable int id, @Valid @RequestBody TaskUpdateDto updatedTask){
+        if(updatedTask.id() != id){
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Mismatched task ID");
+        }
+        Task task = service.updateTask(updatedTask);
+        return ResponseEntity.ok(task);
+    }
+    @GetMapping("/{id}")
+    public ResponseEntity<Task> getTaskById(@PathVariable int id){
+        Task task = service.getTaskById(id);
+        return ResponseEntity.ok(task);
+    }
+    @DeleteMapping("/{id}")
+    public ResponseEntity<String> deleteTask(@PathVariable int id){
+        if(service.deleteTask(id)) {
+            return ResponseEntity.noContent().build();
+        }
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+    }
+
+}

--- a/src/test/java/org/fungover/mmotodo/task/TaskRestControllerTest.java
+++ b/src/test/java/org/fungover/mmotodo/task/TaskRestControllerTest.java
@@ -1,8 +1,6 @@
 package org.fungover.mmotodo.task;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.fungover.mmotodo.exception.TaskNotFoundException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -13,7 +11,6 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
@@ -31,12 +28,13 @@ class TaskRestControllerTest {
     @InjectMocks
     private TaskRestController taskRestController;
 
-    private ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
     @BeforeEach
-    void setUp(){
+    void setUp() {
         mockMvc = MockMvcBuilders.standaloneSetup(taskRestController).build();
     }
+
     @Test
     void getAllTasks() throws Exception {
 
@@ -60,8 +58,8 @@ class TaskRestControllerTest {
 
         // Perform test
         mockMvc.perform(post("/api/tasks")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(taskCreateDto)))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(taskCreateDto)))
                 .andExpect(status().isCreated())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON));
     }
@@ -69,7 +67,7 @@ class TaskRestControllerTest {
     @Test
     void updateTask() throws Exception {
         int taskId = 1;
-        TaskUpdateDto updateDto = new TaskUpdateDto(taskId,"Updated title", "Updated description", "InProgress", 2, 3);
+        TaskUpdateDto updateDto = new TaskUpdateDto(taskId, "Updated title", "Updated description", "InProgress", 2, 3);
 
         Task mockTask = Task.createTestTask(taskId);
 
@@ -82,8 +80,8 @@ class TaskRestControllerTest {
 
         //Perform Test
         mockMvc.perform(put("/api/tasks/" + taskId)
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(updateDto)))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(updateDto)))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON));
     }
@@ -106,16 +104,17 @@ class TaskRestControllerTest {
 
         given(service.deleteTask(1)).willReturn(true);
 
-        mockMvc.perform(delete("/api/tasks/" + taskId ))
+        mockMvc.perform(delete("/api/tasks/" + taskId))
                 .andExpect(status().isNoContent());
     }
+
     @Test
     void deleteTask_NotFound() throws Exception {
         int taskId = 1;
 
         given(service.deleteTask(1)).willReturn(false);
 
-        mockMvc.perform(delete("/api/tasks/" + taskId ))
+        mockMvc.perform(delete("/api/tasks/" + taskId))
                 .andExpect(status().isNotFound());
     }
 }

--- a/src/test/java/org/fungover/mmotodo/task/TaskRestControllerTest.java
+++ b/src/test/java/org/fungover/mmotodo/task/TaskRestControllerTest.java
@@ -1,0 +1,121 @@
+package org.fungover.mmotodo.task;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.fungover.mmotodo.exception.TaskNotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+class TaskRestControllerTest {
+
+    private MockMvc mockMvc;
+
+    @Mock
+    private TaskService service;
+
+    @InjectMocks
+    private TaskRestController taskRestController;
+
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @BeforeEach
+    void setUp(){
+        mockMvc = MockMvcBuilders.standaloneSetup(taskRestController).build();
+    }
+    @Test
+    void getAllTasks() throws Exception {
+
+        mockMvc.perform(get("/api/tasks"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON));
+    }
+
+    @Test
+    void createTask() throws Exception {
+
+        TaskCreateDto taskCreateDto = new TaskCreateDto("Test task", "Test description", "Open");
+
+        //Mock behaviour
+        Task mockTask = new Task();
+        mockTask.setTitle(taskCreateDto.title());
+        mockTask.setDescription(taskCreateDto.description());
+        mockTask.setStatus(taskCreateDto.status());
+
+        given(service.addTask(any(TaskCreateDto.class))).willReturn(mockTask);
+
+        // Perform test
+        mockMvc.perform(post("/api/tasks")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(taskCreateDto)))
+                .andExpect(status().isCreated())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON));
+    }
+
+    @Test
+    void updateTask() throws Exception {
+        int taskId = 1;
+        TaskUpdateDto updateDto = new TaskUpdateDto(taskId,"Updated title", "Updated description", "InProgress", 2, 3);
+
+        Task mockTask = Task.createTestTask(taskId);
+
+        //Mock behaviour
+        mockTask.setTitle(updateDto.title());
+        mockTask.setDescription(updateDto.description());
+        mockTask.setStatus(updateDto.status());
+
+        given(service.updateTask(any(TaskUpdateDto.class))).willReturn(mockTask);
+
+        //Perform Test
+        mockMvc.perform(put("/api/tasks/" + taskId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(updateDto)))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON));
+    }
+
+    @Test
+    void getTaskByIdShouldReturnTaskWithId() throws Exception {
+        int taskId = 1;
+        Task task = Task.createTestTask(taskId);
+
+        given(service.getTaskById(taskId)).willReturn(task);
+
+        mockMvc.perform(get("/api/tasks/" + taskId))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON));
+    }
+
+    @Test
+    void deleteTask_NoContent() throws Exception {
+        int taskId = 1;
+
+        given(service.deleteTask(1)).willReturn(true);
+
+        mockMvc.perform(delete("/api/tasks/" + taskId ))
+                .andExpect(status().isNoContent());
+    }
+    @Test
+    void deleteTask_NotFound() throws Exception {
+        int taskId = 1;
+
+        given(service.deleteTask(1)).willReturn(false);
+
+        mockMvc.perform(delete("/api/tasks/" + taskId ))
+                .andExpect(status().isNotFound());
+    }
+}


### PR DESCRIPTION
# REST endpoints for Tasks

This partly resolves #12 

The reason I havent added any endpoints handling Tasks per Category or Tag is because I believe it would be more 
restful to have them on endpoints like `/tags/{tagId}/tasks` and `/categories/{categoryId}/tasks`

I also thought about implementing Swagger UI in this repo to automate REST documentation.

---
This adds the following endpoints :

`GET /api/tasks`
- Returns all tasks

`POST /api/tasks`
- Adds a new Task

`PUT /api/tasks/{id}`
- Updates Task with {id}

`GET /api/tasks/{id}`
- Returns Task with {id}

`DELETE /api/tasks/{id}`
- Deletes Task with {id}
